### PR TITLE
Added biocViews to help devtools/remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,8 @@ License: file LICENSE
 Encoding: UTF-8
 LazyData: true
 LazyDataCompression: xz
+biocViews:
+    Software
 Imports: 
     igraph,
     RANN,


### PR DESCRIPTION
Currently "bluster" is listed as a depedency but is a Bioconductor package. Installations using `install_github()` will fail because it will not pull in Bioconductor dependencies. Adding biocViews hints devtools and remotes to look at Bioconductor and allows this package to be directly installed off github without manually installing bluster first.