### PR TITLE
Adding seurat v5 compatibility

### DIFF
--- a/R/supercell_2_Seurat.R
+++ b/R/supercell_2_Seurat.R
@@ -12,6 +12,7 @@
 #' @param do.center whether to center gene expression matrix to compute PCA, ignored if \code{!do.preproc}
 #' @param do.scale whether to scale gene expression matrix to compute PCA, ignored if \code{!do.preproc}
 #' @param N.comp number of principal components to use for construction of single-cell kNN network, ignored if \code{!do.preproc}
+#' @param output.assay.version version of the seurat assay in output, \code{`"v4"`} by default, \code{`"v5"`} requires \link[Seurat]{Seurat} v5 installed.
 #'
 #'
 #' @details
@@ -48,7 +49,8 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
                                is.log.normalized = TRUE,
                                do.center = TRUE,
                                do.scale = TRUE,
-                               N.comp = NULL){
+                               N.comp = NULL,
+                               output.assay.version = "v4"){
   N.c <- ncol(SC.GE)
   if(is.null(SC$supercell_size)){
     warning(paste0("supercell_size field of SC is missing, size of all super-cells set to 1"))
@@ -56,44 +58,48 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
   } else {
     supercell_size <- SC$supercell_size
   }
-
+  
   if(length(supercell_size) != N.c){
     stop(paste0("length of SC$supercell_size has to be the same as number of super-cells ", N.c))
   }
-
+  
   ## Name all cells to create Seurat Object
   if(is.null(colnames(SC.GE))){
     colnames(SC.GE) <- as.character(1:N.c)
   }
   counts <- SC.GE
-
+  
   ## If fields is numerical, map them to names
   if(is.numeric(fields)){
     fields <- names(SC)[fields]
   }
-
+  
   ## Keep only available fiedls
   fields <- intersect(fields, names(SC))
-
+  
   if(length(fields) > 0){
     SC.fields <- SC[fields]
   } else {
     SC.fields <- NULL
   }
-
+  
   ## Keep only fields that are specific to cells
   SC.field.length <- lapply(SC.fields, length)
   SC.fields       <- SC.fields[which(SC.field.length == N.c)]
-
+  
   meta     <- data.frame(size = supercell_size, row.names = colnames(SC.GE), stringsAsFactors = FALSE)
-
+  
   if(length(SC.fields) > 0){
     meta <- cbind(meta, SC.fields)
   }
   m.seurat <- Seurat::CreateSeuratObject(counts = SC.GE, meta.data = meta)
-
+  
+  if(packageVersion("Seurat") >= 5){
+    m.seurat[["RNA"]] <- as(object = m.seurat[["RNA"]], Class = "Assay")
+  }
+  
   if(!do.preproc) return(m.seurat)
-
+  
   ## Data preprocessing (optional, but recommended)
   ## Normalize data, so Seurat does not generate warning
   m.seurat <- Seurat::NormalizeData(m.seurat)
@@ -103,7 +109,7 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
     print("Doing: data to normalized data")
     m.seurat@assays$RNA@data <- m.seurat@assays$RNA@counts
   }
-
+  
   ## Sample-weighted scaling
   if(length(unique(meta$size)) > 1){
     print("Doing: weighted scaling")
@@ -112,59 +118,63 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
                                                                     center = do.center,
                                                                     scale = do.scale)))
     print("Done: weighted scaling")
-
+    
   } else {
     print("Doing: unweighted scaling")
     m.seurat <- Seurat::ScaleData(m.seurat)
     print("Done: unweighted scaling")
   }
-
+  
   m.seurat@assays$RNA@misc[["scale.data.weighted"]] <- m.seurat@assays$RNA@scale.data
-
+  
   if(is.null(var.genes)){
     var.genes <- sort(SC$genes.use)
   }
-
-
+  
+  
   if(is.null(N.comp)) N.comp <- min(50, ncol(m.seurat@assays$RNA@counts)-1)
-
+  
   Seurat::VariableFeatures(m.seurat) <- var.genes
   m.seurat <- Seurat::RunPCA(m.seurat, verbose = F, npcs = max(N.comp))
   m.seurat@reductions$pca_seurat <- m.seurat@reductions$pca
-
+  
   my_pca <- supercell_prcomp(X = Matrix::t(SC.GE[var.genes, ]), genes.use = var.genes,
                              fast.pca = TRUE,
                              supercell_size = meta$supercell_size,
                              k = dim(m.seurat@reductions$pca_seurat)[2],
                              do.scale = do.scale, do.center = do.center)
-
+  
   dimnames(my_pca$x) <- dimnames(m.seurat@reductions$pca_seurat)
   m.seurat@reductions$pca@cell.embeddings  <- my_pca$x
   m.seurat@reductions$pca@feature.loadings <- my_pca$rotation
   m.seurat@reductions$pca@stdev            <- my_pca$sdev
-
+  
   m.seurat@reductions$pca_weighted         <- m.seurat@reductions$pca
-
+  
   ## Super-cell network:
   ## 1) create graph field
   m.seurat            <- Seurat::FindNeighbors(m.seurat, compute.SNN = TRUE, verbose = TRUE)
-
+  
   ## 2) add self-loops to our super-cell graph to indicate super-cell size (does not work, as Seurat removes loops...)
-
+  
   if(!is.null(SC$graph.supercells)){
     # SC$graph.supercells <- igraph::add_edges(SC$graph.supercells, edges = rep(1:N.c, each = 2), weight = supercell_size)
     adj.mtx             <- igraph::get.adjacency(SC$graph.supercells, attr = "weight")
-
+    
     ## 3) replace generated Seurat network with the super-cell network
     m.seurat@graphs$RNA_nn@i                <- adj.mtx@i
     m.seurat@graphs$RNA_nn@p                <- adj.mtx@p
     m.seurat@graphs$RNA_nn@Dim              <- adj.mtx@Dim
     m.seurat@graphs$RNA_nn@x                <- adj.mtx@x
     m.seurat@graphs$RNA_nn@factors          <- adj.mtx@factors
-
+    
     m.seurat@graphs$RNA_super_cells         <- m.seurat@graphs$RNA_nn
   } else {
     warning("Super-cell graph was not found in SC object, no super-cell graph was added to Seurat object")
+  }
+  
+  if(packageVersion("Seurat") >= 5 & output.assay.version = "v5"){
+    m.seurat[["RNA"]] <- as(object = m.seurat[["RNA"]], Class = "Assay5")
   }
   return(m.seurat)
 }

--- a/R/supercell_2_Seurat.R
+++ b/R/supercell_2_Seurat.R
@@ -173,7 +173,7 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
     warning("Super-cell graph was not found in SC object, no super-cell graph was added to Seurat object")
   }
   
-  if(packageVersion("Seurat") >= 5 & output.assay.version = "v5"){
+  if(packageVersion("Seurat") >= 5 & output.assay.version == "v5"){
     m.seurat[["RNA"]] <- as(object = m.seurat[["RNA"]], Class = "Assay5")
   }
   return(m.seurat)

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 
 # Coarse-graining of large single-cell RNA-seq data into metacells
-SuperCell is an R package fpr coarse-grainng large single-cell RNA-seq data into metacells and performing downstream analysis at the metacell level. 
+SuperCell is an R package for coarse-graining large single-cell RNA-seq data into metacells and performing downstream analysis at the metacell level. 
 
 The exponential scaling of scRNA-seq data represents an important hurdle for downstream analyses.
 One of the solutions to facilitate the analysis of large-scale and noisy scRNA-seq data is to merge transcriptionally highly similar cells into *metacells*. This concept was first introduced by [*Baran et al., 2019*](https://doi.org/10.1186/s13059-019-1812-2) (MetaCell) and by [*Iacono et al., 2018*](https://doi:10.1101/gr.230771.117) (bigSCale). More recent methods to build *metacells* have been described in [*Ben-Kiki et al. 2022*](https://doi.org/10.1186/s13059-022-02667-1) (MetaCell2), [*Bilous et al., 2022*](https://doi.org/10.1186/s12859-022-04861-1) (SuperCell) and [*Persad et al., 2022*](https://doi.org/10.1038/s41587-023-01716-9) (SEACells). Despite some differences in the implementation, all the methods are network-based and can be summarized as follows: 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Coarse-graining of large single-cell RNA-seq data into metacells
 
-SuperCell is an R package fpr coarse-grainng large single-cell RNA-seq
+SuperCell is an R package for coarse-graining large single-cell RNA-seq
 data into metacells and performing downstream analysis at the metacell
 level.
 

--- a/man/supercell_2_Seurat.Rd
+++ b/man/supercell_2_Seurat.Rd
@@ -13,7 +13,8 @@ supercell_2_Seurat(
   is.log.normalized = TRUE,
   do.center = TRUE,
   do.scale = TRUE,
-  N.comp = NULL
+  N.comp = NULL,
+  output.assay.version = "v4"
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ supercell_2_Seurat(
 \item{do.scale}{whether to scale gene expression matrix to compute PCA, ignored if \code{!do.preproc}}
 
 \item{N.comp}{number of principal components to use for construction of single-cell kNN network, ignored if \code{!do.preproc}}
+
+\item{output.assay.version}{version of the seurat assay in output, \code{`"v4"`} by default, \code{`"v5"`} requires \link[Seurat]{Seurat} v5 installed.}
 }
 \value{
 \link[Seurat]{Seurat} object


### PR DESCRIPTION
The supercell_2_seurat function should be updated to be compatible with Seurat v5.
We can use v4 assay option in case seurat v5 is installed:
`if(packageVersion("Seurat") >= 5){
    m.seurat[["RNA"]] <- as(object = m.seurat[["RNA"]], Class = "Assay")
}`
The assay version in output can be an option (with v4 by default for now). 