### PR TITLE
Fix compatibility issue regarding non-character version specification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Imports:
     proxy,
     methods,
     rlang,
+    withr,
 RoxygenNote: 7.2.3
 Suggests:
     SingleCellExperiment,

--- a/R/supercell_2_Seurat.R
+++ b/R/supercell_2_Seurat.R
@@ -93,7 +93,7 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
     meta <- cbind(meta, SC.fields)
   }
   
-  if(packageVersion("Seurat") >= "5.0.0") {
+  if(packageVersion("Seurat") >= "5.0.0"){
     withr::local_options(list(Seurat.object.assay.version = "v3"))
   }
 
@@ -174,7 +174,7 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
     warning("Super-cell graph was not found in SC object, no super-cell graph was added to Seurat object")
   }
   
-  if(packageVersion("Seurat") >= "5" & output.assay.version == "v5"){
+  if(packageVersion("Seurat") >= "5.0.0" & output.assay.version == "v5"){
     m.seurat[["RNA"]] <- as(object = m.seurat[["RNA"]], Class = "Assay5")
   }
   return(m.seurat)

--- a/R/supercell_2_Seurat.R
+++ b/R/supercell_2_Seurat.R
@@ -93,7 +93,7 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
     meta <- cbind(meta, SC.fields)
   }
   
-  if(packageVersion("Seurat") >= 5) {
+  if(packageVersion("Seurat") >= "5.0.0") {
     withr::local_options(list(Seurat.object.assay.version = "v3"))
   }
 

--- a/R/supercell_2_Seurat.R
+++ b/R/supercell_2_Seurat.R
@@ -94,7 +94,7 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
   }
   m.seurat <- Seurat::CreateSeuratObject(counts = SC.GE, meta.data = meta)
   
-  if(packageVersion("Seurat") >= 5){
+  if(packageVersion("Seurat") >= "5"){
     m.seurat[["RNA"]] <- as(object = m.seurat[["RNA"]], Class = "Assay")
   }
   
@@ -173,7 +173,7 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
     warning("Super-cell graph was not found in SC object, no super-cell graph was added to Seurat object")
   }
   
-  if(packageVersion("Seurat") >= 5 & output.assay.version == "v5"){
+  if(packageVersion("Seurat") >= "5" & output.assay.version == "v5"){
     m.seurat[["RNA"]] <- as(object = m.seurat[["RNA"]], Class = "Assay5")
   }
   return(m.seurat)

--- a/R/supercell_2_Seurat.R
+++ b/R/supercell_2_Seurat.R
@@ -92,11 +92,12 @@ supercell_2_Seurat <- function(SC.GE, SC, fields = c(),
   if(length(SC.fields) > 0){
     meta <- cbind(meta, SC.fields)
   }
-  m.seurat <- Seurat::CreateSeuratObject(counts = SC.GE, meta.data = meta)
   
-  if(packageVersion("Seurat") >= "5"){
-    m.seurat[["RNA"]] <- as(object = m.seurat[["RNA"]], Class = "Assay")
+  if(packageVersion("Seurat") >= 5) {
+    withr::local_options(list(Seurat.object.assay.version = "v3"))
   }
+
+  m.seurat <- Seurat::CreateSeuratObject(counts = SC.GE, meta.data = meta)
   
   if(!do.preproc) return(m.seurat)
   


### PR DESCRIPTION
**Description:** `supercell_2_Seurat` will always fail on the latest R version (4.4.x, specifically) with an error message, no matter what the value of `output.assay.version` is.
```
Error in .make_numeric_version(x, strict, .standard_regexps()$valid_numeric_version) : 
  invalid non-character version specification 'x' (type: double)
```
Detailed traceback:
```
6: stop(msg, domain = NA)
5: .make_numeric_version(x, strict, .standard_regexps()$valid_numeric_version)
4: numeric_version(x)
3: as.numeric_version(e2)
2: Ops.numeric_version(packageVersion("Seurat"), 5)
1: supercell_2_Seurat(SC.GE, SC, fields = c("ident"))
```

It is likely caused by a change in the mechanics for comparing version numbers, as indicated in a similar issue [here](https://github.com/tidyverse/ggplot2/issues/6152#issuecomment-2427778832), which makes direct comparison between `numeric_version` and numeric type invalid.

**Change:** The right operand was changed to character type. For example:
```R
  if(packageVersion("Seurat") >= "5"){
    ...
  }
```

This modification should be compatible with both older and newer versions of R, as indicated in [the archived manual](https://www.rdocumentation.org/packages/utils/versions/3.1.0/topics/packageDescription) for R 3.1.0. I have tested the comparison logic on older versions of R, ranging from R 3.6.0 to R 4.4.0.